### PR TITLE
ページ全体の設定を追加 

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,4 +1,20 @@
-/*
- *= require_tree .
- *= require_self
- */
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-md {
+  max-width: 720px;
+}
+
+.mw-lg {
+  max-width: 960px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def max_width
+    "mw-xl"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,9 +7,19 @@
 
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
 
   <body>
-    <%= yield %>
+        <header>
+    </header>
+    <main>
+      <#% max_width メソッドは application_helper.rb に記載 %>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
### close #4

## 実装内容
ページ全体に共通する内容が書かれているファイル `app/views/layouts/application.html.erb` にスマホ用のビューポートを設定
```
<meta name="viewport" content="width=device-width, initial-scale=1">
```
**[参考]** <https://developers.google.com/web/fundamentals/design-and-ux/responsive?hl=ja#set-the-viewport>
さらに、
```
 <%= yield %>
```
を
```
    <header>
    </header>
    <main>
      <#% max_width メソッドは application_helper.rb に記載 %>
      <div class="base-container <%= max_width %>">
        <%= yield %>
      </div>
    </main>
    <footer>
    </footer>
```
としておき、全ページに共通して必要なCSSを `app/assets/stylesheets/application.css` に設定

```
/* 全体 */ 

.base-container {
  margin: 0 auto;
  padding: 1rem;
}

/* max-width */ 

.mw-md {
  max-width: 720px;
}

.mw-lg {
  max-width: 960px;
}

.mw-xl {
  max-width: 1200px;
}
```

`max_width` メソッドを `app/helpers/application_helper.rb` に定義
。後に条件分岐が必要ですが，現時点では `mw-xl` 固定

```
module ApplicationHelper
  def max_width
    "mw-xl"
  end
end
```

- [ ] 