### PR TITLE
テキスト教材のCSVインポート機能を実装

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -13,6 +13,7 @@ require "action_text/engine"
 require "action_view/railtie"
 require "action_cable/engine"
 require "sprockets/railtie"
+require "csv"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems
@@ -28,7 +29,10 @@ module YanbaruCodeCloneApp
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
-
+    
+    # db ディレクトリ配下のファイルを読み込む
+    config.autoload_paths << Rails.root.join("db")
+    
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,15 +6,6 @@ User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORDputs 'ユーザーの初期データインポートに成功しました。'
 end
 
-class ImportCsv
-  def self.import(path)
-    Text.destroy_all
-     CSV.foreach(path, headers: true) do |row|
-       Text.create!(
-         genre: row["genre"],
-         title: row["title"],
-         content: row["content"]
-       )
-     end
-  end
-end
+# テキスト教材のCSVインポート
+Text.destroy_all
+ImportCsv.import('db/csv_data/text_data.csv')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,16 @@ PASSWORD = 'password'
 User.find_or_create_by!(email: EMAIL) do |user|
   user.password = PASSWORDputs 'ユーザーの初期データインポートに成功しました。'
 end
+
+class ImportCsv
+  def self.import(path)
+    Text.destroy_all
+     CSV.foreach(path, headers: true) do |row|
+       Text.create!(
+         genre: row["genre"],
+         title: row["title"],
+         content: row["content"]
+       )
+     end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,8 @@ PASSWORD = 'password'
 
 # テストユーザーが存在しないときだけ作成
 User.find_or_create_by!(email: EMAIL) do |user|
-  user.password = PASSWORDputs 'ユーザーの初期データインポートに成功しました。'
+  user.password = PASSWORD
+  puts 'ユーザーの初期データインポートに成功しました。'
 end
 
 # テキスト教材のCSVインポート

--- a/lib/autoloads/import_csv.rb
+++ b/lib/autoloads/import_csv.rb
@@ -1,0 +1,13 @@
+class ImportCsv
+    # CSVデータのパスを引数として受け取り、インポート処理を実行
+    def self.import(path)
+       CSV.foreach(path, headers: true) do |row|
+         Text.create!(
+            genre: row["genre"],
+           title: row["title"],
+           content: row["content"]
+         )
+       end
+    end
+    puts "TextへのCSVデータをインポート完了"
+  end


### PR DESCRIPTION
## close #11 

## 実装内容

-  texts テーブルにデータを投入する処理を追加
   - ターミナルでrails db:seedを実行時インポートされる

## 参考資料

- [やんばるCODE教材（CSVインポート）](https://arcane-gorge-21903.herokuapp.com/texts/217)

## チェックリスト


- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
