### PR TITLE
フラッシュとページ全体の設定の追加の実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,7 +2,6 @@
  *= require_tree .
  *= require_self
  */
-@import "bootstrap/scss/bootstrap";
 
 @import "bootstrap/scss/bootstrap";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,4 +2,35 @@
  *= require_tree .
  *= require_self
  */
- @import "bootstrap/scss/bootstrap";
+@import "bootstrap/scss/bootstrap";
+
+@import "bootstrap/scss/bootstrap";
+
+.alert-notice {
+  @extend .alert-info;
+}
+
+.alert-alert {
+  @extend .alert-danger;
+}
+
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-md {
+  max-width: 720px;
+}
+
+.mw-lg {
+  max-width: 960px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,9 @@
 module ApplicationHelper
+
+module ApplicationHelper
+  def max_width
+    "mw-xl"
+  end
+end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,5 @@
 module ApplicationHelper
-
-module ApplicationHelper
   def max_width
     "mw-xl"
   end
-end
-
 end

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,6 @@
+<% flash.each do |flash_type, msg| %>
+  <div class="alert alert-<%= flash_type %>" role="alert">
+    <a href="#" class="close" data-dismiss="alert">×</a>
+    <%= msg %>
+  </div>
+<% end %> 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,19 +10,20 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-
   <body>
-    <% if user_signed_in? %>
+
+    <header>
+        <% if user_signed_in? %>
       <%= link_to "アカウント編集", edit_user_registration_path %>
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: { confirm: "ログアウトしますか？" } %>
     <% else %>
       <%= link_to "ログイン", new_user_session_path %>
       <%= link_to "アカウント登録", new_user_registration_path %>
     <% end %>
-
-<%= render 'layouts/flash' %>
-    <header>
     </header>
+
+    <%= render 'layouts/flash' %>
+
     <main>
       <div class="base-container <%= max_width %>">
         <%= yield %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,10 +6,10 @@
     <%= csp_meta_tag %>
     
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
+
 
   <body>
     <% if user_signed_in? %>
@@ -19,6 +19,18 @@
       <%= link_to "ログイン", new_user_session_path %>
       <%= link_to "アカウント登録", new_user_registration_path %>
     <% end %>
-    <%= yield %>
+
+<%= render 'layouts/flash' %>
+    <header>
+    </header>
+    <main>
+      <#% max_width メソッドは application_helper.rb に記載 %>
+      <div class="base-container <%= max_width %>">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+    </footer>
+
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,6 @@
     <header>
     </header>
     <main>
-      <#% max_width メソッドは application_helper.rb に記載 %>
       <div class="base-container <%= max_width %>">
         <%= yield %>
       </div>


### PR DESCRIPTION
## close #23

## 修正内容：フラッシュ

- リンクコードの位置の変更
- フラッシュの位置の変更

## 反映内容：ページ全体の設定の追加

ページ全体に共通する内容が書かれているファイル `app/views/layouts/application.html.erb` にスマホ用のビューポートを設定しておきましょう。

```html
<meta name="viewport" content="width=device-width, initial-scale=1">
```

【参考】https://developers.google.com/web/fundamentals/design-and-ux/responsive?hl=ja#set-the-viewport

さらに，

```erb
    <%= yield %>
```

を

```erb
    <header>
    </header>
    <main>
      <#% max_width メソッドは application_helper.rb に記載 %>
      <div class="base-container <%= max_width %>">
        <%= yield %>
      </div>
    </main>
    <footer>
    </footer>
```

としておき，全ページに共通して必要なCSSを `app/assets/stylesheets/application.css` に設定して下さい。

```css
/* 全体 */ 

.base-container {
  margin: 0 auto;
  padding: 1rem;
}

/* max-width */ 

.mw-md {
  max-width: 720px;
}

.mw-lg {
  max-width: 960px;
}

.mw-xl {
  max-width: 1200px;
}
```

さらに，`max_width` メソッドを `app/helpers/application_helper.rb` に定義しましょう。後に条件分岐が必要ですが，現時点では `mw-xl` 固定としておきましょう。

```rb
module ApplicationHelper
  def max_width
    "mw-xl"
  end
end
```

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認