### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'devise-i18n'
 gem 'devise-bootstrap-views'
 # ページネーション
 gem 'kaminari'
+#マークダウン記法の文字列をHTMLに変換
+gem 'redcarpet'
 
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,8 @@ gem 'devise-bootstrap-views'
 gem 'kaminari'
 #マークダウン記法の文字列をHTMLに変換
 gem 'redcarpet'
-
+#シンタックスハイライト
+gem 'coderay'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -263,6 +264,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,3 +47,7 @@
 body {
   padding-bottom: 70px;
 }
+
+a, a:visited, a:focus, a:hover {
+  text-decoration: none;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -2,4 +2,8 @@ class TextsController < ApplicationController
   def index
     @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(:genre)
   end
+
+  def show
+    @text = Text.find(params[:id])
+  end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,26 @@
+module MarkdownHelper
+  def markdown(text)
+    markdown = Redcarpet::Markdown.new(html_renderer, markdown_extensions)
+    markdown.render(text).html_safe
+  end
+
+  private
+
+  def html_renderer
+    Redcarpet::Render::HTML
+  end
+
+  def markdown_extensions
+    {
+      autolink: true,
+      space_after_headers: true,
+      no_intra_emphasis: true,
+      fenced_code_blocks: true,
+      tables: true,
+      hard_wrap: true,
+      xhtml: true,
+      lax_html_blocks: true,
+      strikethrough: true
+    }
+  end
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -8,6 +8,11 @@ module MarkdownHelper
 
   def html_renderer
     Redcarpet::Render::HTML
+    ::Coderayify.new(
+      filter_html: true,
+      hard_wrap: true,
+      link_attributes: { rel: 'nofollow', target: "_blank" }
+    )
   end
 
   def markdown_extensions

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -7,8 +7,8 @@
         <%= link_to text, class: "card border-dark h-100" do %>
           <img class="card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%">
           <div class="card-body">
-            <p class="card-text"><%= text.title %></p>
-            <p class="card-text">【<%= text.genre %>】</p>
+            <p class="card-text text-dark"><%= text.title %></p>
+            <p class="card-text text-dark">【<%= text.genre %>】</p>
           </div>
         <% end %>
       </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -4,13 +4,13 @@
   <div class="row">
     <% @texts.each do |text| %>
       <div class="col-12 col-md-6 col-lg-4 mb-5">
-        <div class="card border-dark h-100">
+        <%= link_to text, class: "card border-dark h-100" do %>
           <img class="card-img-top" src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%">
           <div class="card-body">
             <p class="card-text"><%= text.title %></p>
             <p class="card-text">【<%= text.genre %>】</p>
           </div>
-        </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @text.title %></h1>
+<p><%= @text.content %></p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,7 +1,4 @@
 <h1><%= @text.title %></h1>
 <p>
-  <% renderer = Redcarpet::Render::HTML %>
-  <% extensions = { tables: true } %>
-  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
-  <%= markdown.render(@text.content).html_safe %>
+  <%= markdown(@text.content) %>
 </p>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,2 +1,7 @@
 <h1><%= @text.title %></h1>
-<p><%= @text.content %></p>
+<p>
+  <% renderer = Redcarpet::Render::HTML %>
+  <% extensions = { tables: true } %>
+  <% markdown = Redcarpet::Markdown.new(renderer, extensions) %>
+  <%= markdown.render(@text.content).html_safe %>
+</p>

--- a/lib/autoloads/coderayify.rb
+++ b/lib/autoloads/coderayify.rb
@@ -1,0 +1,34 @@
+class Coderayify < Redcarpet::Render::HTML
+  def block_code(code, language)
+    # コードブロックの拡張子を取得
+    ext = retrieve_extension(language)
+    # 適用するシンタックスハイライトの言語を決める
+    lang = case ext
+           when "rb"
+             :ruby
+           when "yml"
+             :yaml
+           else
+             ext.to_sym
+           end
+    CodeRay.scan(code, lang).div
+  end
+
+  private
+
+  # 拡張子を取得するメソッド
+  def retrieve_extension(language)
+    if language.blank?
+      # コードブロックの開始宣言で「```」の後に拡張子が与えられていない場合は md 形式とみなす
+      "md"
+    elsif language.include?(":")
+      # コードブロックの開始宣言が「```rb:sample.rb」の場合は rb 形式とみなす
+      language.split(':')[0]
+    elsif language.include?(".")
+      # コードブロックの開始宣言が「```sample.rb」の場合は rb 形式とみなす
+      language.split('.')[-1]
+    else
+      language
+    end
+  end
+end


### PR DESCRIPTION
## close #14

## 実装内容
- 一覧ページから詳細ページへ飛べるようにリンクを設置
- 詳細ページの実装
  - 内容がマークダウンに対応した表示ができるように設定


## 参考資料

- Markdownの導入
  - [やんばるCODE教材](https://www.yanbaru-code.com/texts/224)
- BootstrapのCards全体をリンクにする
  -  [Qiita](https://qiita.com/s10aim_tana/items/c0abf3fcf2430659e8e9)

## チェックリスト
- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
- 詳細画面の細かいスタイルの調整は別タスクにする
  - Rouge gemを使用する
