### PR TITLE
Line詳細ページの実装

### DIFF
--- a/app/controllers/lines_controller.rb
+++ b/app/controllers/lines_controller.rb
@@ -4,5 +4,6 @@ class LinesController < ApplicationController
   end
 
   def show
+    @line = Line.find(params[:id])
   end
 end

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -12,7 +12,7 @@
       <tr>
         <th scope="row"><%= i %></th>
         <td><%= line.genre %></td>
-        <td><%= link_to "#{line.title}", line ,target: :_blank%></td>
+        <td><%= link_to "#{line.title}", line , target: :_blank , rel: "noopener noreferrer"%></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/lines/index.html.erb
+++ b/app/views/lines/index.html.erb
@@ -12,7 +12,7 @@
       <tr>
         <th scope="row"><%= i %></th>
         <td><%= line.genre %></td>
-        <td><%= link_to "#{line.title}", line %></td>
+        <td><%= link_to "#{line.title}", line ,target: :_blank%></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/lines/show.html.erb
+++ b/app/views/lines/show.html.erb
@@ -1,2 +1,3 @@
-<h1>Lines#show</h1>
-<p>Find me in app/views/lines/show.html.erb</p>
+<div class="mx-auto mt-5"  style="width: 500px;">
+  <%= markdown(@line.content) %>
+</div>


### PR DESCRIPTION
## close #56 

## 実装内容
- Line詳細ページの実装
  - linesControllerのshowメソッドに記述
  - 詳細ページのViewを作成
  - 一覧ページからのリンクを別タブに飛ばすように変更

## 参考資料

- リンクを別タブで表示
  - [Qiita](https://qiita.com/Kazuhiro_Mimaki/items/b3f2d718d2bae9083290)
- bootstrapでの中央寄せ
  - [Qiita](https://qiita.com/Kazuhiro_Mimaki/items/b3f2d718d2bae9083290)

## チェックリスト
- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認
